### PR TITLE
add dummy unit_of_measurement to numbers if missing

### DIFF
--- a/dispatchers/HomeAssistantDispatcher.js
+++ b/dispatchers/HomeAssistantDispatcher.js
@@ -807,6 +807,14 @@ class HomeAssistantDispatcher {
             case 'number':
             case 'float':
             case 'integer':
+                const unit = capability.units && typeof capability.units === 'object' ? capability.units['en'] : capability.units;
+                cfg = {
+                    type: 'sensor',
+                    payload: {
+                        unit_of_measurement: unit ? unit : " "
+                    }
+                };
+                return cfg;    
             case 'string':
             case 'enum':
                 cfg = {


### PR DESCRIPTION
if there is not unit_of_measurement, HA displays the data as a bar (like strings) and not a graph. Adding a dummy unit_of_measurement (a single space) seems to fix the display issue.

I had this issue with Aqara vibration sensor / vibration data which has no unit.