### PR TITLE
Probably fixes  #69

### DIFF
--- a/dispatchers/HomieDispatcher.js
+++ b/dispatchers/HomieDispatcher.js
@@ -242,7 +242,7 @@ class HomieDispatcher {
     getNodeName(device) {
         let path = [device.name];
         if (this.topicIncludeZone) {
-            path.unshift(device.zone && device.zone.name ? device.zone.name : DEFAULT_ZONE);
+            path.unshift(device.zoneName ? device.zoneName : DEFAULT_ZONE);
         }
         if (this.topicIncludeClass) {
             path.unshift(device.class || DEFAULT_CLASS);


### PR DESCRIPTION
I couldnt test it, but it seems you should use device.zoneName instead of device.zone.name  (device.zone is the uuid of the zone)