### PR TITLE
Add app setting to reduce CPU load for broadcast

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ node_modules/ws/
 inspector_modules
 build
 package-lock.json
+
+# Added by Homey CLI
+/.homeybuild/

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,25 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "node",
+            "request": "attach",
+            "restart": true,
+            "name": "Attach MQTT-Hub Homey Pro 23",
+            "address": "192.168.1.15",
+            "port": 9229,
+            "localRoot": "${workspaceFolder}",
+            "remoteRoot": "/app/"
+        },
+        {
+            "type": "node",
+            "request": "attach",
+            "restart": true,
+            "name": "Attach MQTT-Hub to Homey Pro 19",
+            "address": "192.168.1.13",
+            "port": 9229,
+            "localRoot": "${workspaceFolder}",
+            "remoteRoot": "/"
+        }
+    ]
+}

--- a/locales/en.json
+++ b/locales/en.json
@@ -102,7 +102,9 @@
     "willMessage": "Last will message",
     "reset": "Reset",
     "defaultSettings": "",
-    "restoreSettings": "Restore default settings"
+    "restoreSettings": "Restore default settings",
+    "performance": "Performance",
+    "performanceDelay": "Send message delay (ms)"
   },
   "tab2": {
     "title": "Devices",

--- a/mqtt/MessageQueue.js
+++ b/mqtt/MessageQueue.js
@@ -7,7 +7,7 @@ const Message = require('./Message');
 const DELAY = 0; // Wait 10 ms before sending next message to give Homey some breathing time
 
 class MessageQueue {
-    constructor(mqttClient) {
+    constructor(mqttClient, delay = DELAY) {
         this.mqttClient = mqttClient;
         this.queue = [];
         this.messages = new Map();
@@ -15,6 +15,7 @@ class MessageQueue {
 
         // Clear message queue when MQTT Client uninstalled
         this.mqttClient.onUnRegistered.subscribe(() => this.clear());
+        this.delay = delay;
     }
 
     add(topic, payload, opt, process) {
@@ -81,9 +82,9 @@ class MessageQueue {
                     Log.error(e);
                 }
 
-                if (DELAY) {
+                if (this.delay) {
                     try {
-                        await delay(DELAY); // give Homey some breathing time
+                        await delay(this.delay); // give Homey some breathing time
                     } catch (e) {
                         Log.error("MessageQueue: delay failure");
                         Log.error(e);

--- a/settings/index.html
+++ b/settings/index.html
@@ -299,6 +299,18 @@
                     </div>
                 </div>
 
+                <!--Performance -->
+                <div data-i18n="tab1.performance" class="text-header">Performance</div>
+                <div id="performanceSettings">
+                    <div class="setting">
+                        <label class="settings-item-description" data-i18n="tab1.performanceDelay">Send message delay</label>
+                        <div class="settings-itemgroup">
+                            <input id="performanceDelay" type="text" onblur="saveSettings()">
+                        </div>
+                    </div>
+                </div>
+
+                <!--Reset -->
                 <div data-i18n="tab1.reset" class="text-header">Reset</div>
                 <div class="setting">
                     <label class="settings-item-description" data-i18n="tab1.defaultSettings"></label>

--- a/settings/settings.js
+++ b/settings/settings.js
@@ -47,6 +47,8 @@ const defaultSettings = {
     "willMessage": "offline",
 
     "loglevel": "info",
+
+    "performanceDelay": "0",
 };
 
 //////////////////////////////////////////////


### PR DESCRIPTION
Hi Harrie,

I added app settings for send delay to be able to set individual delay and created this pull request for.

The reason for this change is:
HomeyPro23 is processing messages so fast that the MqttClient app CPU usage is hitting 100% and gets stopped due to CPU warnings. MqttHub gets stopped due to Memory warning. 
This delay makes both apps much more stable on HP23. I use 100ms delay now and got no stopped apps since this change.

I changed the app settings page (new field at the end under "Performance" header).
The setting is passed creating the MessageQueue instance. So the new setting is read on app start.
I also added the app events for memwarn and cpuwarn and the handler functions. But it seems these events are not called anymore on HP23. I left the code to get a debug log if Athom is answering my comment on Slack and hopefully add these events for HP23.

I forgot to uncheck the .gitignore file (Homey-CLI added the /.homeybuild/) and ./vscode/ folder (I added debug options for HP23).
You can ignore/revert these changes.

I hope the fix is in your interest and you can add it to your branch and publish a new test version.
Many thanks in advance.

Ronny
